### PR TITLE
Update WindowRules.conf

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -44,6 +44,9 @@ windowrulev2 = workspace 6 silent, class:^(virt-manager)$
 windowrulev2 = workspace 9 silent, class:^([Aa]udacious)$
 
 # windowrule v2 - float
+windowrulev2 = float, class:^(it.mijorus.gearlever)$ 
+windowrulev2 = float, class:^(ide.schmidhuberj.tubefeeder)$  # Pipeline youtube client
+windowrulev2 = float, class:^(com.github.tchx84.Flatseal)$ 
 windowrulev2 = float, class:^(org.kde.polkit-kde-authentication-agent-1)$ 
 windowrulev2 = float, class:([Zz]oom|onedriver|onedriver-launcher)$
 windowrulev2 = float, class:([Tt]hunar), title:(File Operation Progress)


### PR DESCRIPTION
Added three common programs to the float defaults  windowrulev2 = float, class:^(it.mijorus.gearlever)$  windowrulev2 = float, class:^(ide.schmidhuberj.tubefeeder)$  # Pipeline youtube client windowrulev2 = float, class:^(com.github.tchx84.Flatseal)$

# Pull Request

## Description

Please read these instructions and remove unnecessary text.

- Try to include a summary of the changes and which issue is fixed.
- Also include relevant motivation and context (if applicable).
- List any dependencies that are required for this change. (e.g., packages or other PRs)
- Provide a link if there is an issue related to this pull request. e.g., Fixes # (issue)
- Please add Reviewers, Assignees, Labels, Projects, and Milestones to the PR. (if applicable)

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ x] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [ x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
 

Add any other context about the problem here.

 The flatseal for managing flatpak permissions, and gearlever for managing appimages should be popups by default  IMO.  There are small GUIs   The Pipeline is a rust based YouTube video viewer 
